### PR TITLE
feat: add GitHub Actions workflow for automated npm publishing and re…

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -1,86 +1,58 @@
-name: Auto Publish Major Releases
+name: Auto Publish on Main
 
 on:
   push:
     branches:
       - main  # Trigger on every successful merge to main
 
-      
 permissions:
   id-token: write
   contents: write  # Required for pushing tags and creating releases
 
 jobs:
-  check-and-publish:
+  publish:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Extract version from package.json
+      - name: Get version from package.json
         id: version
         run: |
-          # Read version from package.json
           VERSION=$(node -p "require('./package.json').version")
           echo "package_version=$VERSION" >> $GITHUB_OUTPUT
-
-          # Parse major, minor, patch
-          MAJOR=$(echo $VERSION | cut -d. -f1)
-          MINOR=$(echo $VERSION | cut -d. -f2)
-          PATCH=$(echo $VERSION | cut -d. -f3)
-
-          echo "major=$MAJOR" >> $GITHUB_OUTPUT
-          echo "minor=$MINOR" >> $GITHUB_OUTPUT
-          echo "patch=$PATCH" >> $GITHUB_OUTPUT
-
-          # Check if this is a minor/major release (patch should be 0 and minor >= 2)
-          # Based on the rule: only publish when minor version changes with 2+ points difference
-          if [[ "$PATCH" == "0" && "$MINOR" -ge 2 ]]; then
-            echo "should_publish=true" >> $GITHUB_OUTPUT
-            echo "✅ Version $VERSION qualifies for auto-publish (minor >= 2, patch = 0)"
-          else
-            echo "should_publish=false" >> $GITHUB_OUTPUT
-            echo "⏭️ Version $VERSION does not qualify for auto-publish"
-          fi
+          echo "📦 Publishing version $VERSION"
 
       - name: Setup Node.js
-        if: steps.version.outputs.should_publish == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
-        if: steps.version.outputs.should_publish == 'true'
         run: npm ci
 
       - name: Build package
-        if: steps.version.outputs.should_publish == 'true'
         run: npm run build
 
       - name: Publish to npm
-        if: steps.version.outputs.should_publish == 'true'
         run: npm publish
 
       - name: Create Git Tag
-        if: steps.version.outputs.should_publish == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "v${{ steps.version.outputs.package_version }}" -m "Release v${{ steps.version.outputs.package_version }}"
-          git push origin "v${{ steps.version.outputs.package_version }}"
+          git tag -a "v${{ steps.version.outputs.package_version }}" -m "Release v${{ steps.version.outputs.package_version }}" || true
+          git push origin "v${{ steps.version.outputs.package_version }}" || true
 
       - name: Create GitHub Release
-        if: steps.version.outputs.should_publish == 'true'
         uses: softprops/action-gh-release@v1
         with:
           tag_name: v${{ steps.version.outputs.package_version }}
           name: Release ${{ steps.version.outputs.package_version }}
           body: |
-            ## 🚀 Auto-published Release v${{ steps.version.outputs.package_version }}
-            
-            This release was automatically published because the minor version is >= 2.
+            ## 🚀 Release v${{ steps.version.outputs.package_version }}
             
             ### Install
             ```bash
@@ -95,9 +67,3 @@ jobs:
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Skip notification
-        if: steps.version.outputs.should_publish == 'false'
-        run: |
-          echo "📌 Skipping publish for version ${{ steps.version.outputs.package_version }}"
-          echo "Reason: Patch releases (x.y.Z where Z > 0) or minor versions < 2 are ignored"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nxt-gen-cli",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "The ultimate Next.js scaffold CLI generator. Customize your stack with Prisma, React Query, Shadcn, HeroUI, and more in seconds.",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
This pull request updates the release workflow to simplify and automate publishing to npm on every merge to the `main` branch, regardless of version number. The previous logic that restricted publishing to certain version patterns has been removed, making the process more streamlined. Additionally, the package version has been incremented.

Workflow automation and simplification:

* The `.github/workflows/auto-publish.yml` workflow was updated to trigger on every push to `main` and to always run the publish steps, removing all logic that previously limited publishing to only certain version numbers. This includes removing checks for major/minor/patch versions and the conditional execution of steps.
* The workflow job was renamed from `check-and-publish` to `publish`, and unnecessary notification steps for skipped publishes were removed.

Package version update:

* The `package.json` version was bumped from `1.1.0` to `1.1.1`.…lease creation on main branch pushes